### PR TITLE
Add estimated reading time to blog posts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ yarn-error.log*
 
 # vscode settings
 .vscode
+
+# typescript build info
+tsconfig.tsbuildinfo

--- a/src/__tests__/posts.test.ts
+++ b/src/__tests__/posts.test.ts
@@ -25,6 +25,7 @@ describe('Posts', () => {
         expect(post.meta).toHaveProperty('author')
         expect(post.meta).toHaveProperty('excerpt')
         expect(post.meta).toHaveProperty('tags')
+        expect(post.meta).toHaveProperty('readingTime')
 
         expect(typeof post.meta.title).toBe('string')
         expect(typeof post.meta.date).toBe('string')
@@ -32,6 +33,8 @@ describe('Posts', () => {
         expect(typeof post.meta.excerpt).toBe('string')
         expect(Array.isArray(post.meta.tags)).toBe(true)
         expect(post.meta.tags.length).toBeGreaterThan(0)
+        expect(typeof post.meta.readingTime).toBe('number')
+        expect(post.meta.readingTime).toBeGreaterThan(0)
       })
     })
 
@@ -52,11 +55,11 @@ describe('Posts', () => {
 
       posts.forEach((post) => {
         if (post.meta.twitterProfile) {
-          expect(() => new URL(post.meta.twitterProfile)).not.toThrow()
+          expect(() => new URL(post.meta.twitterProfile!)).not.toThrow()
         }
 
         if (post.meta.coverImageCreditUrl) {
-          expect(() => new URL(post.meta.coverImageCreditUrl)).not.toThrow()
+          expect(() => new URL(post.meta.coverImageCreditUrl!)).not.toThrow()
         }
       })
     })

--- a/src/__tests__/reading-time.test.ts
+++ b/src/__tests__/reading-time.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest'
+import { getAllPostsMeta, calculateReadingTime } from '../lib/posts'
+
+describe('Reading Time Calculation', () => {
+  it('should calculate reading time for posts', async () => {
+    const posts = await getAllPostsMeta()
+
+    // Ensure we have posts to test with
+    expect(posts.length).toBeGreaterThan(0)
+
+    // Check that all posts have readingTime
+    posts.forEach(({ slug, meta }) => {
+      expect(meta.readingTime).toBeDefined()
+      expect(typeof meta.readingTime).toBe('number')
+      expect(meta.readingTime).toBeGreaterThan(0)
+      expect(meta.readingTime).toEqual(Math.floor(meta.readingTime)) // Should be a whole number
+    })
+  })
+
+  it('should respect manual readingTime in frontmatter if provided', async () => {
+    // This test will pass if we have posts with manual readingTime
+    // Otherwise it just verifies the calculation works
+    const posts = await getAllPostsMeta()
+
+    posts.forEach(({ meta }) => {
+      // All posts should have readingTime (either calculated or manual)
+      expect(meta.readingTime).toBeGreaterThan(0)
+    })
+  })
+
+  it('should provide reasonable reading times', async () => {
+    const posts = await getAllPostsMeta()
+
+    posts.forEach(({ slug, meta }) => {
+      // Reading time should be reasonable (1-60 minutes for blog posts)
+      expect(meta.readingTime).toBeGreaterThanOrEqual(1)
+      expect(meta.readingTime).toBeLessThanOrEqual(60)
+    })
+  })
+})
+
+// Test the calculation function directly
+describe('Reading Time Calculation Function', () => {
+  it('should handle empty content', () => {
+    expect(calculateReadingTime('')).toBe(1)
+    expect(calculateReadingTime('   ')).toBe(1)
+  })
+
+  it('should calculate reading time for simple text', () => {
+    // 225 words should equal 1 minute (default WPM)
+    const words = Array(225).fill('word').join(' ')
+    expect(calculateReadingTime(words)).toBe(1)
+
+    // 450 words should equal 2 minutes
+    const moreWords = Array(450).fill('word').join(' ')
+    expect(calculateReadingTime(moreWords)).toBe(2)
+  })
+
+  it('should handle markdown syntax removal', () => {
+    const contentWithMarkdown = `
+# Heading
+This is **bold** and *italic* text.
+\`inline code\` should be counted.
+
+\`\`\`javascript
+// This code block should be ignored
+const example = 'ignored';
+\`\`\`
+
+[Link text](https://example.com) should keep the text.
+![Image alt](image.jpg) should be removed.
+    `.trim()
+
+    const readingTime = calculateReadingTime(contentWithMarkdown)
+    expect(readingTime).toBeGreaterThan(0)
+    expect(typeof readingTime).toBe('number')
+  })
+
+  it('should use custom words per minute', () => {
+    const words = Array(100).fill('word').join(' ')
+
+    // At 100 WPM, 100 words = 1 minute
+    expect(calculateReadingTime(words, 100)).toBe(1)
+
+    // At 200 WPM, 100 words = 0.5 minute, rounded up to 1
+    expect(calculateReadingTime(words, 200)).toBe(1)
+  })
+
+  it('should round up fractional minutes', () => {
+    // 112 words at 225 WPM = 0.498 minutes, should round to 1
+    const words = Array(112).fill('word').join(' ')
+    expect(calculateReadingTime(words, 225)).toBe(1)
+
+    // 226 words at 225 WPM = 1.004 minutes, should round to 2
+    const moreWords = Array(226).fill('word').join(' ')
+    expect(calculateReadingTime(moreWords, 225)).toBe(2)
+  })
+})

--- a/src/app/[slug]/page.tsx
+++ b/src/app/[slug]/page.tsx
@@ -118,6 +118,7 @@ export default async function PostPage({ params }: Props) {
             author={post.meta.author}
             twitterProfile={post.meta.twitterProfile}
             tags={post.meta.tags}
+            readingTime={post.meta.readingTime}
           />
           <CoverImage
             image={post.meta.coverImage}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -60,6 +60,7 @@ export default async function HomePage() {
               author={meta.author}
               twitterProfile={meta.twitterProfile}
               tags={meta.tags}
+              readingTime={meta.readingTime}
             />
             <CoverImage
               image={meta.coverImage}

--- a/src/app/tags/[tag]/page.tsx
+++ b/src/app/tags/[tag]/page.tsx
@@ -88,6 +88,7 @@ export default async function TagPage({ params }: Props) {
             author={meta.author}
             twitterProfile={meta.twitterProfile}
             tags={meta.tags}
+            readingTime={meta.readingTime}
           />
           <CoverImage image={meta.coverImage} />
           <p>{meta.excerpt}</p>

--- a/src/components/PostDateAndAuthor.tsx
+++ b/src/components/PostDateAndAuthor.tsx
@@ -6,12 +6,14 @@ interface Props {
   date: Date
   author: string
   twitterProfile?: string
+  readingTime: number
 }
 
 const PostDateAndAuthor: React.FC<Props> = ({
   date,
   author,
   twitterProfile,
+  readingTime,
 }) => {
   return (
     <div className={styles.root}>
@@ -26,6 +28,8 @@ const PostDateAndAuthor: React.FC<Props> = ({
         ) : (
           <span className={styles.author}>{author}</span>
         )}
+        <span className={styles.hyphen}>—</span>
+        <span>{readingTime} min read</span>
       </div>
     </div>
   )

--- a/src/components/PostMeta.tsx
+++ b/src/components/PostMeta.tsx
@@ -8,15 +8,23 @@ interface Props {
   author: string
   twitterProfile?: string
   tags: string[]
+  readingTime: number
 }
 
-const PostMeta: React.FC<Props> = ({ date, author, twitterProfile, tags }) => {
+const PostMeta: React.FC<Props> = ({
+  date,
+  author,
+  twitterProfile,
+  tags,
+  readingTime,
+}) => {
   return (
     <div className={styles.root}>
       <PostDateAndAuthor
         date={date}
         author={author}
         twitterProfile={twitterProfile}
+        readingTime={readingTime}
       />
       <PostTags tags={tags} />
     </div>


### PR DESCRIPTION
## Summary
- Add reading time calculation at build time for all blog posts
- Display reading time in post metadata alongside date and author
- Support manual reading time override via frontmatter

## Features
- Calculates reading time based on 225 WPM average reading speed
- Automatically strips markdown/MDX syntax for accurate word count
- Always shows at least 1 minute for very short content
- Preserves manual `readingTime` values from frontmatter if provided

## Implementation
- Enhanced `posts.ts` with `calculateReadingTime()` function
- Updated `PostMeta` and `PostDateAndAuthor` components to display reading time
- Added comprehensive tests for calculation logic and integration
- Updated all page components to pass reading time prop

## Test Coverage
- Unit tests for reading time calculation function
- Integration tests for post metadata processing
- Validation tests ensuring all posts have reading time

🤖 Generated with [Claude Code](https://claude.ai/code)